### PR TITLE
Adds subText to the chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ options: {
 
   // the domain for the data, default is [0, 100]
   domain: [0, 365],
-  
+
   // whether arc for the gauge should have rounded corners
   roundedCorners: true,
 
@@ -96,7 +96,9 @@ options: {
     // the text to display in the center
     // this could be a string or a callback that returns a string
     // if a callback is provided it will be called with (value, options)
-    text: null
+    text: null,
+    // the text to display beneath the text specified above
+    subText: null,
   }
 }
 ```

--- a/samples/basic.html
+++ b/samples/basic.html
@@ -48,10 +48,6 @@
             display: true,
             text: 'Radial gauge chart'
           },
-          centerArea: {
-            text: '75%',
-            subText: 'TOTAL JOB POSTINGS',
-          },
           centerPercentage: 80
         }
       };

--- a/samples/basic.html
+++ b/samples/basic.html
@@ -48,6 +48,10 @@
             display: true,
             text: 'Radial gauge chart'
           },
+          centerArea: {
+            text: '75%',
+            subText: 'TOTAL JOB POSTINGS',
+          },
           centerPercentage: 80
         }
       };

--- a/src/controllers/controller.radialGauge.js
+++ b/src/controllers/controller.radialGauge.js
@@ -166,6 +166,27 @@ export default Chart => {
       );
     },
 
+    wrapText(context, text, x, y, maxWidth, lineHeight) {
+      const words = text.split(' ');
+      let line = '';
+
+      for (let n = 0; n < words.length; n += 1) {
+        const testLine = line.concat(words[n], ' ');
+        const metrics = context.measureText(testLine);
+        const testWidth = metrics.width;
+        if (testWidth > maxWidth && n > 0) {
+          context.textAlign = 'center';
+          context.fillText(line, x, y);
+          line = words[n].concat(' ');
+          y += lineHeight;
+        } else {
+          line = testLine;
+        }
+      }
+      context.textAlign = 'center';
+      context.fillText(line, x, y);
+    },
+
     drawCenterText({ options, value }) {
       let fontSize = options.fontSize || `${(this.innerRadius / 50).toFixed(2)}em`;
       if (typeof fontSize === 'number') {
@@ -204,11 +225,16 @@ export default Chart => {
         // Calculate the x-coordinate of the text.
         textX = Math.round(-textWidth / 2);
 
-        // If the text won't fix, then don't display it. See above for details.
-        if (textWidth < 2 * this.innerRadius * 0.7) {
-          // Draw the sub-text 30% below the main text.
-          this.chart.ctx.fillText(text, textX, this.innerRadius * 0.3);
-        }
+        // Draw the sub-text 30% below the main text. Wrap the text and center
+        // it.
+        this.wrapText(
+          this.chart.ctx,
+          text,
+          0,
+          this.innerRadius * 0.3,
+          this.innerRadius * 2 * 0.8,
+          this.innerRadius / 100 + (this.innerRadius * 0.2),
+        );
       }
     },
 

--- a/src/controllers/controller.radialGauge.js
+++ b/src/controllers/controller.radialGauge.js
@@ -180,12 +180,35 @@ export default Chart => {
       this.chart.ctx.font = `${fontSize} ${fontFamily}`;
       this.chart.ctx.fillStyle = color;
       this.chart.ctx.textBaseline = 'middle';
-      const textWidth = this.chart.ctx.measureText(text).width;
-      const textX = Math.round(-textWidth / 2);
+      let textWidth = this.chart.ctx.measureText(text).width;
+      let textX = Math.round(-textWidth / 2);
 
-      // only display the text if it fits
+      // Only display the text if it fits. The Radius is half the width of the
+      // circle * 2 is the diameter and 0.8 is 80% of that.
       if (textWidth < 2 * this.innerRadius * 0.8) {
         this.chart.ctx.fillText(text, textX, 0);
+      }
+
+      // Draw any sub-text.
+      text = options.subText;
+      if (text) {
+        // The font-size is half of of the calculated size above.
+        fontSize = `${(this.innerRadius / 100).toFixed(2)}em`;
+
+        // Set the size of the font.
+        this.chart.ctx.font = `${fontSize} ${fontFamily}`;
+
+        // Calculate the width of the sub-text.
+        textWidth = this.chart.ctx.measureText(text).width;
+
+        // Calculate the x-coordinate of the text.
+        textX = Math.round(-textWidth / 2);
+
+        // If the text won't fix, then don't display it. See above for details.
+        if (textWidth < 2 * this.innerRadius * 0.7) {
+          // Draw the sub-text 30% below the main text.
+          this.chart.ctx.fillText(text, textX, this.innerRadius * 0.3);
+        }
       }
     },
 


### PR DESCRIPTION
- The subText (if specified) appears under the text in a smaller font
- Often seen on many radial gauge components
- Can be used instead of the title that appears above the chart for instance to provide more self-contained context